### PR TITLE
Rtcom fixes

### DIFF
--- a/src/modapi/datapipes.h
+++ b/src/modapi/datapipes.h
@@ -66,7 +66,7 @@ extern datapipe_struct call_backend_error_pipe;
 extern datapipe_struct vibrate_pipe;
 
 //input: MessageProperties
-extern datapipe_struct message_recived_pipe;
+extern datapipe_struct message_received_pipe;
 
 //input: MessageProperties
 extern datapipe_struct message_send_pipe;

--- a/src/modules/comm-ofono.c
+++ b/src/modules/comm-ofono.c
@@ -537,7 +537,7 @@ static void new_sms_cb(GDBusConnection *connection,
 	message->time = mktime(&tm);
 	
 	if(message->line_identifier && message->text)
-		execute_datapipe(&message_recived_pipe, message);
+		execute_datapipe(&message_received_pipe, message);
 
 	error:
 	message_properties_free(message);

--- a/src/modules/commtest.c
+++ b/src/modules/commtest.c
@@ -159,8 +159,8 @@ static gboolean mock_incomeing_message(void *data)
 	
 	msg->time = time(NULL);
 	msg->outbound = false;
-	sphone_module_log(LL_DEBUG, "Mock recived message %s with text \"%s\"", msg->line_identifier, msg->text);
-	execute_datapipe(&message_recived_pipe, msg);
+	sphone_module_log(LL_DEBUG, "Mock received message %s with text \"%s\"", msg->line_identifier, msg->text);
+	execute_datapipe(&message_received_pipe, msg);
 	message_properties_free(msg);
 	return false;
 }

--- a/src/modules/contacts-evolution.c
+++ b/src/modules/contacts-evolution.c
@@ -211,7 +211,7 @@ const gchar *sphone_module_init(void** data)
 		e_book_client_connect(address_book_src, 0, NULL, book_ready_callback, book);
 		append_filter_to_datapipe(&call_new_pipe, call_filter, book);
 		append_filter_to_datapipe(&call_properties_changed_pipe, call_filter, book);
-		append_filter_to_datapipe(&message_recived_pipe, message_filter, book);
+		append_filter_to_datapipe(&message_received_pipe, message_filter, book);
 		append_filter_to_datapipe(&contact_fill_pipe, contact_filter, book);
 		g_object_unref(address_book_src);
 	}
@@ -223,6 +223,6 @@ void sphone_module_exit(void* data)
 {
 	remove_filter_from_datapipe(&call_new_pipe, call_filter, data);
 	remove_filter_from_datapipe(&call_properties_changed_pipe, call_filter, data);
-	remove_filter_from_datapipe(&message_recived_pipe, message_filter, data);
+	remove_filter_from_datapipe(&message_received_pipe, message_filter, data);
 	remove_filter_from_datapipe(&contact_fill_pipe, contact_filter, data);
 }

--- a/src/modules/external-exec.c
+++ b/src/modules/external-exec.c
@@ -86,7 +86,7 @@ static void message_send_trigger(gconstpointer data, gpointer user_data)
 	}
 }
 
-static void message_recived_trigger(gconstpointer data, gpointer user_data)
+static void message_received_trigger(gconstpointer data, gpointer user_data)
 {
 	(void)user_data;
 	const MessageProperties *msg = data;
@@ -105,7 +105,7 @@ const gchar *sphone_module_init(void** data)
 	append_trigger_to_datapipe(&call_new_pipe, new_call_trigger, NULL);
 	append_trigger_to_datapipe(&call_properties_changed_pipe, call_properties_changed_trigger, NULL);
 	
-	append_trigger_to_datapipe(&message_recived_pipe, message_recived_trigger, NULL);
+	append_trigger_to_datapipe(&message_received_pipe, message_received_trigger, NULL);
 	append_trigger_to_datapipe(&message_send_pipe, message_send_trigger, NULL);
 
 	return NULL;
@@ -119,6 +119,6 @@ void sphone_module_exit(void* data)
 	remove_trigger_from_datapipe(&call_new_pipe, new_call_trigger, NULL);
 	remove_trigger_from_datapipe(&call_properties_changed_pipe, call_properties_changed_trigger, NULL);
 
-	remove_trigger_from_datapipe(&message_recived_pipe, message_recived_trigger, NULL);
+	remove_trigger_from_datapipe(&message_received_pipe, message_received_trigger, NULL);
 	remove_trigger_from_datapipe(&message_send_pipe, message_send_trigger, NULL);
 }

--- a/src/modules/gui/gtk2/gtk-gui-message-threads.c
+++ b/src/modules/gui/gtk2/gtk-gui-message-threads.c
@@ -55,7 +55,7 @@ static void gtk_gui_msg_threads_list_double_click_callback(GtkTreeView *view, Gt
 		sphone_log(LL_DEBUG, "BACKEND: %i", contact.backend);
 		contact.line_identifier = (char*)g_value_get_string(&line_id_value);
 		gchar *name = g_value_get_string(&name_value);
-		if(g_strcmp0(name, "<unkown>") != 0)
+		if(g_strcmp0(name, "<unknown>") != 0)
 			contact.name = (char*)name;
 		gtk_gui_show_thread_for_contact(&contact);
 		g_value_unset(&line_id_value);

--- a/src/modules/gui/gtk2/gtk-gui-utils.c
+++ b/src/modules/gui/gtk2/gtk-gui-utils.c
@@ -38,12 +38,12 @@ GtkTreeModel *gtk_gui_new_model_from_calls(GList *calls)
 		char *timestr = gtk_gui_date_to_new_string(call->start_time);
 		CommBackend *backend = sphone_comm_get_backend(call->backend);
 		gtk_list_store_set(store, &iter,
-		              GTK_UI_MOD_NAME, call->contact && call->contact->name ? call->contact->name : "<unkown>",
+		              GTK_UI_MOD_NAME, call->contact && call->contact->name ? call->contact->name : "<unknown>",
 		              GTK_UI_MOD_LINE_ID, call->line_identifier,
 		              GTK_UI_MOD_TIME, timestr,
 		              GTK_UI_MOD_TEXT, NULL,
 		              GTK_UI_MOD_BACKEND, call->backend,
-		              GTK_UI_MOD_BACKEND_STR, backend ? backend->name : "unkown", -1);
+		              GTK_UI_MOD_BACKEND_STR, backend ? backend->name : "unknown", -1);
 		g_free(timestr);
 	}
 	return GTK_TREE_MODEL(store);
@@ -61,12 +61,12 @@ GtkTreeModel *gtk_gui_new_model_from_messages(GList *messages)
 		char *timestr = gtk_gui_time_to_new_string(msg->time);
 		CommBackend *backend = sphone_comm_get_backend(msg->backend);
 		gtk_list_store_set(store, &iter,
-		              GTK_UI_MOD_NAME, msg->contact && msg->contact->name ? msg->contact->name : "<unkown>",
+		              GTK_UI_MOD_NAME, msg->contact && msg->contact->name ? msg->contact->name : "<unknown>",
 		              GTK_UI_MOD_LINE_ID, msg->line_identifier,
 		              GTK_UI_MOD_TIME, timestr,
 		              GTK_UI_MOD_TEXT, msg->text,
 		              GTK_UI_MOD_BACKEND, msg->backend,
-		              GTK_UI_MOD_BACKEND_STR, backend ? backend->name : "unkown", -1);
+		              GTK_UI_MOD_BACKEND_STR, backend ? backend->name : "unknown", -1);
 		g_free(timestr);
 	}
 	return GTK_TREE_MODEL(store);
@@ -84,12 +84,12 @@ GtkTreeModel *gtk_gui_new_model_from_contacts(GList *contacts)
 		gtk_list_store_append(store, &iter);
 		CommBackend *backend = sphone_comm_get_backend(contact->backend);
 		gtk_list_store_set(store, &iter,
-		              GTK_UI_MOD_NAME, contact->name ?: "<unkown>" ,
+		              GTK_UI_MOD_NAME, contact->name ?: "<unknown>" ,
 		              GTK_UI_MOD_LINE_ID, contact->line_identifier,
 		              GTK_UI_MOD_TIME, NULL,
 		              GTK_UI_MOD_TEXT, NULL,
 		              GTK_UI_MOD_BACKEND, contact->backend,
-		              GTK_UI_MOD_BACKEND_STR, backend ? backend->name : "unkown", -1);
+		              GTK_UI_MOD_BACKEND_STR, backend ? backend->name : "unknown", -1);
 	}
 	return GTK_TREE_MODEL(store);
 }

--- a/src/modules/gui/gtk2/ui-message-threads-gtk.c
+++ b/src/modules/gui/gtk2/ui-message-threads-gtk.c
@@ -108,7 +108,7 @@ static void remove_thread_view(GtkWidget *widget, gpointer data)
 	const Contact *watch_contact = g_object_get_data(G_OBJECT(text_view), "contact");
 	shown_contacts = g_slist_remove(shown_contacts, watch_contact);
 	remove_trigger_from_datapipe(&message_send_pipe, new_message_trigger, text_view);
-	remove_trigger_from_datapipe(&message_recived_pipe, new_message_trigger, text_view);
+	remove_trigger_from_datapipe(&message_received_pipe, new_message_trigger, text_view);
 }
 
 static void gtk_gui_thread_view_reply_cb(GtkButton* button, Contact *contact)
@@ -187,7 +187,7 @@ void gtk_gui_show_thread_for_contact(Contact *contact)
 	g_signal_connect(GTK_WIDGET(window), "hide", G_CALLBACK(remove_thread_view), text_view);
 	shown_contacts = g_slist_prepend(shown_contacts, contact_cpy);
 	append_trigger_to_datapipe(&message_send_pipe, new_message_trigger, text_view);
-	append_trigger_to_datapipe(&message_recived_pipe, new_message_trigger, text_view);
+	append_trigger_to_datapipe(&message_received_pipe, new_message_trigger, text_view);
 	gtk_text_view_set_editable(GTK_TEXT_VIEW(text_view), false);
 	gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(text_view), false);
 	gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(text_view), GTK_WRAP_WORD_CHAR);

--- a/src/modules/gui/gtk2/ui-messages-gtk.c
+++ b/src/modules/gui/gtk2/ui-messages-gtk.c
@@ -321,7 +321,7 @@ const gchar *sphone_module_init(void** data)
 #ifdef ENABLE_LIBHILDON
 	hildon_init();
 #endif
-	append_trigger_to_datapipe(&message_recived_pipe, gui_sms_incoming_callback, NULL);
+	append_trigger_to_datapipe(&message_received_pipe, gui_sms_incoming_callback, NULL);
 	gui_id = gui_register(NULL, gtk_gui_sms_send_show, NULL, NULL, NULL);
 	return NULL;
 }
@@ -331,5 +331,5 @@ void sphone_module_exit(void* data)
 {
 	(void)data;
 	gui_remove(gui_id);
-	remove_trigger_from_datapipe(&message_recived_pipe, gui_sms_incoming_callback, NULL);
+	remove_trigger_from_datapipe(&message_received_pipe, gui_sms_incoming_callback, NULL);
 }

--- a/src/modules/manager.c
+++ b/src/modules/manager.c
@@ -133,7 +133,7 @@ static void call_changed_trigger(const void *data, void *user_data)
 	check_needed_state();
 }
 
-static void message_recived_trigger(const void *data, void *user_data)
+static void message_received_trigger(const void *data, void *user_data)
 {
 	(void)user_data;
 	const MessageProperties *msg = data;
@@ -165,7 +165,7 @@ const gchar *sphone_module_init(void** data)
 	(void)data;
 	append_trigger_to_datapipe(&call_new_pipe, call_new_trigger, NULL);
 	append_trigger_to_datapipe(&call_properties_changed_pipe, call_changed_trigger, NULL);
-	append_trigger_to_datapipe(&message_recived_pipe, message_recived_trigger, NULL);
+	append_trigger_to_datapipe(&message_received_pipe, message_received_trigger, NULL);
 	return NULL;
 }
 
@@ -175,5 +175,5 @@ void sphone_module_exit(void* data)
 	(void)data;
 	remove_trigger_from_datapipe(&call_new_pipe, call_new_trigger, NULL);
 	remove_trigger_from_datapipe(&call_properties_changed_pipe, call_changed_trigger, NULL);
-	remove_trigger_from_datapipe(&message_recived_pipe, message_recived_trigger, NULL);
+	remove_trigger_from_datapipe(&message_received_pipe, message_received_trigger, NULL);
 }

--- a/src/modules/playback-gstreamer.c
+++ b/src/modules/playback-gstreamer.c
@@ -137,7 +137,7 @@ static void audio_play_looping_trigger(gconstpointer data, gpointer user_data)
 	const char *filename = (const char*)data;
 	
 	if(!filename) {
-		sphone_module_log(LL_WARN, "%s recived invalid file name", __func__);
+		sphone_module_log(LL_WARN, "%s received invalid file name", __func__);
 		return;
 	}
 	
@@ -152,7 +152,7 @@ static void audio_play_once_trigger(gconstpointer data, gpointer user_data)
 	const char *filename = (const char*)data;
 	
 	if(!filename) {
-		sphone_module_log(LL_WARN, "%s recived invalid file name", __func__);
+		sphone_module_log(LL_WARN, "%s received invalid file name", __func__);
 		return;
 	}
 	

--- a/src/modules/store-rtcom.c
+++ b/src/modules/store-rtcom.c
@@ -87,7 +87,7 @@ static void call_properties_changed_trigger(const void *data, void *user_data)
 	rtcom_el_event_free(ev);
 }
 
-static RTComElEvent *create_mesage_event(const MessageProperties *msg)
+static RTComElEvent *create_message_event(const MessageProperties *msg)
 {
 	RTComElEvent *ev = rtcom_el_event_new();
 
@@ -115,7 +115,7 @@ static RTComElEvent *create_mesage_event(const MessageProperties *msg)
 	return ev;
 }
 
-static void message_recived_trigger(const void *data, void *user_data)
+static void message_received_trigger(const void *data, void *user_data)
 {
 	RTComEl *el = user_data;
 	const MessageProperties *msg = data;
@@ -124,7 +124,7 @@ static void message_recived_trigger(const void *data, void *user_data)
 	if(!backend)
 		return;
 
-	RTComElEvent *ev = create_mesage_event(msg);
+	RTComElEvent *ev = create_message_event(msg);
 	RTCOM_EL_EVENT_SET_FIELD(ev, outgoing, false);
 
 	if(rtcom_el_add_event(el, ev, NULL) < 0)
@@ -142,7 +142,7 @@ static void message_send_trigger(const void *data, void *user_data)
 	if(!backend)
 		return;
 
-	RTComElEvent *ev = create_mesage_event(msg);
+	RTComElEvent *ev = create_message_event(msg);
 	RTCOM_EL_EVENT_SET_FIELD(ev, outgoing, true);
 
 	if(rtcom_el_add_event(el, ev, NULL) < 0)
@@ -151,7 +151,7 @@ static void message_send_trigger(const void *data, void *user_data)
 	rtcom_el_event_free(ev);
 }
 
-static MessageProperties *convert_to_message_proparites(RTComElIter *iter, Contact *contact)
+static MessageProperties *convert_to_message_properties(RTComElIter *iter, Contact *contact)
 {
 	char *line_identifier;
 	char *local_uid;
@@ -243,7 +243,7 @@ static GList *get_messages_for_contact(Contact *contact)
 
 	if(iterSms) {
 		do {
-			MessageProperties *msg = convert_to_message_proparites(iterSms, contact);
+			MessageProperties *msg = convert_to_message_properties(iterSms, contact);
 			if(msg)
 				messages = g_list_append(messages, msg);
 		} while(rtcom_el_iter_next(iterSms));
@@ -251,7 +251,7 @@ static GList *get_messages_for_contact(Contact *contact)
 
 	if(iterChat) {
 		do {
-			MessageProperties *msg = convert_to_message_proparites(iterChat, contact);
+			MessageProperties *msg = convert_to_message_properties(iterChat, contact);
 			if(msg)
 				messages = g_list_append(messages, msg);
 		} while(rtcom_el_iter_next(iterChat));
@@ -358,7 +358,7 @@ const gchar *sphone_module_init(void** data)
 	sphone_module_log(LL_INFO, "Successfully opened rtcom-eventlogger database");
 
 	append_trigger_to_datapipe(&call_properties_changed_pipe, call_properties_changed_trigger, evlog);
-	append_trigger_to_datapipe(&message_recived_pipe, message_recived_trigger, evlog);
+	append_trigger_to_datapipe(&message_received_pipe, message_received_trigger, evlog);
 	append_trigger_to_datapipe(&message_send_pipe, message_send_trigger, evlog);
 
 	id = store_register_backend(get_messages_for_contact, get_calls_for_contact);
@@ -372,7 +372,7 @@ void sphone_module_exit(void* data)
 	(void)data;
 	if(evlog) {
 		remove_trigger_from_datapipe(&call_properties_changed_pipe, call_properties_changed_trigger, evlog);
-		remove_trigger_from_datapipe(&message_recived_pipe, message_recived_trigger, evlog);
+		remove_trigger_from_datapipe(&message_received_pipe, message_received_trigger, evlog);
 		remove_trigger_from_datapipe(&message_send_pipe, message_send_trigger, evlog);
 		store_unregister_backend(id);
 		g_object_unref(evlog);

--- a/src/utils/datapipes.c
+++ b/src/utils/datapipes.c
@@ -34,7 +34,7 @@ datapipe_struct call_properties_changed_pipe;
 
 datapipe_struct vibrate_pipe;
 
-datapipe_struct message_recived_pipe;
+datapipe_struct message_received_pipe;
 datapipe_struct message_send_pipe;
 
 datapipe_struct contact_fill_pipe;
@@ -58,7 +58,7 @@ void datapipes_init(void)
 	setup_datapipe(&call_properties_changed_pipe);
 	setup_datapipe(&vibrate_pipe);
 	setup_datapipe(&message_send_pipe);
-	setup_datapipe(&message_recived_pipe);
+	setup_datapipe(&message_received_pipe);
 	setup_datapipe(&notification_raise_pipe);
 	setup_datapipe(&call_accept_pipe);
 	setup_datapipe(&contact_show_pipe);
@@ -81,7 +81,7 @@ void datapipes_exit(void)
 	free_datapipe(&call_properties_changed_pipe);
 	free_datapipe(&vibrate_pipe);
 	free_datapipe(&message_send_pipe);
-	free_datapipe(&message_recived_pipe);
+	free_datapipe(&message_received_pipe);
 	free_datapipe(&notification_raise_pipe);
 	free_datapipe(&call_accept_pipe);
 	free_datapipe(&contact_show_pipe);

--- a/src/utils/types.c
+++ b/src/utils/types.c
@@ -80,9 +80,9 @@ void contact_print(const Contact *contact, const char *module_name)
 		CommBackend *backend = sphone_comm_get_backend(contact->backend);
 		sphone_log(LL_DEBUG, "%s%sContact %s %s from %s",
 				   module_name ?: "", module_name ? ": " : "",
-				   contact->name ?: "<unkown>",
+				   contact->name ?: "<unknown>",
 				   contact->line_identifier ?: "",
-				   backend ? backend->name : "unkown");
+				   backend ? backend->name : "unknown");
 	} else {
 		sphone_log(LL_DEBUG, "%s%sContact: NULL", module_name ?: "", module_name ? ": " : "" );
 	}


### PR DESCRIPTION
This fixes up the local_uid/remote_uid swap and also fixes some typos that were visible in the UI, as well as some obvious code typos.

One thing that's still lacking is to get the name of contacts that aren't known, but whose names are provided when receiving the SMS, so currently many SMSes have no remote_name, which makes them show up as empty in Conversations currently.