### PR TITLE
vcm: set correct backend_id for rtcom local_uid

### DIFF
--- a/src/modules/voicecallmanager/comm-voicecallmanager-maemoprovider.cpp
+++ b/src/modules/voicecallmanager/comm-voicecallmanager-maemoprovider.cpp
@@ -40,9 +40,11 @@ void MaemoProvider::registerBackend()
 	};
 
 	backend_id = id;
-	QString tmp = QString(backend_id).replace("/org/freedesktop/Telepathy/Account/", "");
+
+	QString tmp = QString(id).replace("/org/freedesktop/Telepathy/Account/", "");
 	backend_name = g_strdup(tmp.toStdString().c_str());
-	sphone_backend_id = sphone_comm_add_backend(backend_name, backend_id.toUtf8(), schemes, BACKEND_FLAG_CALL, fields, char_valid);
+	char* _backend_id = g_strdup(backend_name);
+	sphone_backend_id = sphone_comm_add_backend(backend_name, _backend_id, schemes, BACKEND_FLAG_CALL, fields, char_valid);
 
 	sphone_module_log(LL_DEBUG, "Registered backend: %s", backend_name);
 }


### PR DESCRIPTION
Now the log should show things like ring/tel/account0

We probably need to fix wrong entries for those who used the previous logging, with something like:

    update events set local_uid = 'ring/tel/account0' where local_uid LIKE 'sphone%';

This is of course would not work for xmpp/sip calls, but those aren't being used by many anyway I think.